### PR TITLE
Admin oauth updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.5.3'
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'postmark-rails', '~> 0.20.0'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.6'
 gem 'sass-rails', '~> 5.0'
-gem 'sidekiq', '~> 5.2.3'
+gem 'sidekiq'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'postmark-rails', '~> 0.20.0'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.6'
 gem 'sass-rails', '~> 5.0'
-gem 'sidekiq'
+gem 'sidekiq', '~> 5.2.3'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -160,7 +162,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.2.2)
+    redis (4.1.4)
     regexp_parser (1.8.2)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
@@ -197,10 +199,11 @@ GEM
       faraday (> 0.8, < 2.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
-    sidekiq (6.1.2)
-      connection_pool (>= 2.2.2)
+    sidekiq (5.2.9)
+      connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
-      redis (>= 4.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 4.2)
     simplecov (0.19.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -263,7 +266,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
-  sidekiq
+  sidekiq (~> 5.2.3)
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,5 +274,8 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock
 
+RUBY VERSION
+   ruby 2.5.3p105
+
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
-  sidekiq (~> 5.2.3)
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -22,7 +22,7 @@ module Admin
     end
 
     def project
-      @project ||= current_user.projects.find_by(hash_id: params[:id])
+      @project ||= Project.find_by(hash_id: params[:id])
     end
   end
 end

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -14,6 +14,7 @@ class ClonesController < ApplicationController
     if project
       clone = project.clones.new(students: params[:students], user: current_user, url: '')
       if clone.save
+        clone.update(message: 'sending to sidekiq')
         ProjectBoardClonerWorker.perform_later(project, clone, params[:email])
         redirect_to root_path, alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
       else

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -12,13 +12,15 @@ class ClonesController < ApplicationController
   def create
     project = Project.find_by(hash_id: params[:project_hash_id])
     if project
-      clone = project.clones.new(students: params[:students], user: current_user)
+      clone = project.clones.new(students: params[:students], user: current_user, url: '')
       if clone.save
         ProjectBoardClonerWorker.perform_later(project, clone, params[:email])
         redirect_to root_path, alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
+      else
+        redirect_to root_path, alert: "We're sorry but we were unable to clone the project board. If you continue to experience difficulty reach out to your instructor or point of contact."
       end
     else
-      redirect_to root_path, alert: "We're sorry but we were unable to clone the project board. Make sure the link to your Github repo was entered correctly and try again. If you continue to experience difficulty reach out to your instructor or point of contact."
+      redirect_to root_path, alert: "We're sorry but we were unable to clone the project board."
     end
   end
 

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -36,6 +36,7 @@ class ClonesController < ApplicationController
   def destroy
     # TODO Move this to the admin namespace
     project = current_user.projects.find_by(hash_id: params[:project_id])
+    project = Project.find_by(hash_id: params[:project_id]) if project.nil? and current_user.admin?
     clone = project.clones.find(params[:id])
 
     if clone.destroy

--- a/app/exceptions/board_cloning_error.rb
+++ b/app/exceptions/board_cloning_error.rb
@@ -1,3 +1,0 @@
-class BoardCloningError < StandardError
-end
-

--- a/app/facades/dashboard_facade.rb
+++ b/app/facades/dashboard_facade.rb
@@ -5,6 +5,9 @@ class DashboardFacade
 
   def projects
     @projects ||= user.projects
+    if user.admin?
+      @projects = Project.all.order(:project_board_base_url)
+    end
   end
 
   def project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,4 +25,10 @@ class Project < ApplicationRecord
 
     [url_segments[1], url_segments[2]].join("/")
   end
+
+  def get_clones
+    clones.joins(:user)
+        .where(project: self)
+        .order('users.nickname asc, users.email asc, clones.created_at desc')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,19 +3,22 @@ class User < ApplicationRecord
   has_many :clones, dependent: :destroy
 
   def self.from_omniauth(auth)
-    User.find_or_create_by(uid: auth.uid) do |user|
-      is_admin = false
+    user = User.find_by(uid: auth.uid)
+    is_admin = false
+    if user.nil?
+      user = User.create(uid: auth.uid)
       client = Octokit::Client.new(access_token: auth.credentials.token)
       approved_orgs = ApprovedOrganizations.all
       found_org = client.orgs.find { |org| org.login.in?(approved_orgs) }
 
       is_admin = true if found_org
-
       user.admin = is_admin
-      user.nickname = auth.info.nickname
-      user.token = auth.credentials.token
-      user.name = auth.info.name
-      user.email = auth.info.email
     end
+    user.nickname = auth.info.nickname
+    user.token = auth.credentials.token
+    user.name = auth.info.name
+    user.email = auth.info.email
+    user.save
+    user
   end
 end

--- a/app/services/project_board_cloner.rb
+++ b/app/services/project_board_cloner.rb
@@ -101,7 +101,7 @@ class ProjectBoardCloner
 
   def create_columns!
     column_templates.each.with_index(1) do |column_template, index|
-      write_message("Creating column #{index}.")
+      write_message("Creating column #{index} and copy cards.")
       ColumnCloner.run!(column_template, forked_repo, clone.github_project_id, staff_client)
     end
   end

--- a/app/services/project_board_cloner.rb
+++ b/app/services/project_board_cloner.rb
@@ -13,6 +13,7 @@ class ProjectBoardCloner
 
   def run
     begin
+      write_message("getting started!")
       turn_on_auto_paginate!
       fork_repo!
       invite_staff_member_to_repo!
@@ -23,9 +24,9 @@ class ProjectBoardCloner
       create_columns!
       add_to_dashboard_project!
       email_student!
-      write_message!
+      write_message("all done!")
     rescue => e
-      write_message!
+      write_message(e.message)
       raise e
     end
 
@@ -116,8 +117,8 @@ class ProjectBoardCloner
   end
 
   def write_message(message)
-    clone.update(message: message)
-    clone.save!
+    @clone.update(message: message)
+    @clone.save!
   end
 
   def base_project

--- a/app/services/project_board_cloner.rb
+++ b/app/services/project_board_cloner.rb
@@ -41,17 +41,17 @@ class ProjectBoardCloner
     :project_number, :forked_repo, :staff_client, :student_client
 
   def fork_repo!
-    @message = "Forking repo to student account."
+    write_message("Forking repo to student account.")
     @forked_repo = student_client.fork(project.repo_path)
   end
 
   def invite_staff_member_to_repo!
-    @message = "Inviting staff member to student repo."
+    write_message("Inviting staff member to student repo.")
     student_client.invite_user_to_repository(forked_repo.full_name, project.user.nickname)
   end
 
   def accept_repo_invitation!
-    @message = "Accepting staff invitations."
+    write_message("Accepting staff invitations.")
     page, per_page = 1, 100
     no_more_invitations, found_invitation = false, false
     invites = []
@@ -84,37 +84,38 @@ class ProjectBoardCloner
   end
 
   def clone_project_board!
-    @message = "Cloning project board."
+    write_message("Cloning project board.")
     @cloned_project_board ||= student_client.create_project(repo_path, project.name)
   end
 
   def enable_issues!
-    @message = "Enabling issues on student repo."
+    write_message("Enabling issues on student repo.")
     student_client.edit_repository(repo_path, has_issues: true)
   end
 
   def update_clone!
-    @message = "Saving GitHub project id in the database."
+    write_message("Saving GitHub project id in the database.")
     clone.update!(github_project_id: cloned_project_board.id, url: cloned_project_board.html_url)
   end
 
   def create_columns!
     column_templates.each.with_index(1) do |column_template, index|
-      @message = "Creating column #{index}."
+      write_message("Creating column #{index}.")
       ColumnCloner.run!(column_template, forked_repo, clone.github_project_id, staff_client)
     end
   end
 
   def add_to_dashboard_project!
-    @message = "Adding reference to dashboard project."
+    write_message("Adding reference to dashboard project.")
     staff_client.create_project_card(project.github_column, note: cloned_project_board.html_url)
   end
 
   def email_student!
+    write_message("sending email to student")
     CloneMailer.with(email: email, clone: clone).send_notification.deliver_now
   end
 
-  def write_message!
+  def write_message(message)
     clone.update(message: message)
   end
 

--- a/app/services/project_board_cloner.rb
+++ b/app/services/project_board_cloner.rb
@@ -117,6 +117,7 @@ class ProjectBoardCloner
 
   def write_message(message)
     clone.update(message: message)
+    clone.save!
   end
 
   def base_project
@@ -138,7 +139,9 @@ class ProjectBoardCloner
   end
 
   def turn_on_auto_paginate!
+    write_message("enabling auto_paginate for staff")
     staff_client.auto_paginate = true
+    write_message("enabling auto_paginate for students")
     student_client.auto_paginate = true
   end
 end

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -6,18 +6,18 @@
 
 <table>
   <tr>
-    <th>Students</th>
+    <th>Student(s)</th>
     <th>Repo URL</th>
     <th>Status</th>
     <th>Last Updated</th>
     <th>Actions</th>
   </tr>
-  <% @project.clones.each do |clone| %>
+  <% @project.get_clones.each do |clone| %>
     <tr>
       <td><%= clone.students %></td>
       <td><%= link_to clone.url, clone.url %></td>
       <td><%= clone.message %></td>
-      <td><%= clone.updated_at %></td>
+      <td><%= distance_of_time_in_words(Time.now, clone.updated_at) %> ago</td>
       <td>
         <%= link_to "Delete",
                     project_clone_path(clone.project, clone),

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -1,6 +1,6 @@
 <h3><%= @project.name %></h3>
 <ul>
-  <li><strong>Link to send students:</strong> <%= link_to new_project_clone_path(project_id: @project.hash_id), new_project_clone_path(project_id: @project.hash_id) %></li>
+  <li><strong>Link to send students:</strong> <%= link_to new_project_clone_path(project_id: @project.hash_id), new_project_clone_path(project_id: @project.hash_id), protocol: "https" %></li>
   <li><strong>Project Board:</strong> <%= link_to @project.board_url, @project.board_url %></li>
 </ul>
 

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -1,6 +1,6 @@
 <h3><%= @project.name %></h3>
 <ul>
-  <li><strong>Link to send students:</strong> <%= link_to new_project_clone_path(project_id: @project.hash_id), new_project_clone_path(project_id: @project.hash_id), protocol: "https" %></li>
+  <li><strong>Link to send students:</strong> <%= link_to new_project_clone_url(project_id: @project.hash_id), new_project_clone_url(project_id: @project.hash_id) %></li>
   <li><strong>Project Board:</strong> <%= link_to @project.board_url, @project.board_url %></li>
 </ul>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -5,7 +5,7 @@
     <h3>Existing Project Board Templates</h3>
     <ol>
     <% @facade.projects.each do |project| %>
-      <li><%= link_to project.name, admin_project_path(project) %></li>
+      <li><%= link_to project.name, admin_project_path(project) %>, created by <%= project.user.name %> / <%= project.user.email %></li>
     <% end %>
     </ol>
     </div>

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -26,4 +26,35 @@ feature 'User creates a new clone' do
 
     expect(current_path).to eq(root_path)
   end
+
+  scenario 'admin can delete clone' do
+    instructor = create(:instructor, nickname: 'iandouglas')
+
+    project = create(:project,
+                     name: "BE3 Group Project",
+                     user: instructor,
+                     project_board_base_url: "https://github.com/turingschool-examples/watch-and-learn/projects/1",
+                     github_column: 9804554
+    )
+    student = create(:student)
+    clone = create(:clone,
+                   students: 'Richard H.',
+                   project: project,
+                   user: student,
+                   url: 'http://abc/123'
+    )
+
+    stub_omniauth
+    allow(ApprovedOrganizations).to receive(:all).and_return(%w(turingschool))
+    visit root_path
+    click_link "Sign in with GitHub"
+
+    visit admin_project_path(project)
+
+    expect(page).to have_content(clone.url)
+    click_link 'Delete'
+
+    expect(current_path).to eq(admin_project_path(project))
+    expect(page).to_not have_content(clone.url)
+  end
 end

--- a/spec/models/clone_spec.rb
+++ b/spec/models/clone_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include Rails.application.routes.url_helpers
 
 RSpec.describe Clone, type: :model do
   # let(:instructor) { create(:instructor) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -31,5 +31,23 @@ RSpec.describe Project, type: :model do
 
       expect(project.repo_path).to eq('ian/douglas')
     end
+
+    scenario '.get_clones' do
+      project = create(:project, user: instructor, project_board_base_url: 'http://github.com/ian/douglas')
+      student_2 = create(:student, nickname: 'AwesomeCoder')
+      student_3 = create(:student, nickname: 'ZeroCool')
+      s1_clone_1 = create(:clone, project: project, user: student, created_at: 10.seconds.ago)   # 3rd
+      s1_clone_2 = create(:clone, project: project, user: student, created_at: 5.seconds.ago)    # 2nd
+      s2_clone_1 = create(:clone, project: project, user: student_2, created_at: 10.seconds.ago) # 1st
+      s3_clone_1 = create(:clone, project: project, user: student_3, created_at: 5.seconds.ago)  # 4th
+      s3_clone_2 = create(:clone, project: project, user: student_3, created_at: 10.seconds.ago) # 5th
+
+      clone_list = project.get_clones
+      expect(clone_list[0].id).to eq(s2_clone_1.id)
+      expect(clone_list[1].id).to eq(s1_clone_2.id)
+      expect(clone_list[2].id).to eq(s1_clone_1.id)
+      expect(clone_list[3].id).to eq(s3_clone_1.id)
+      expect(clone_list[4].id).to eq(s3_clone_2.id)
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-include Rails.application.routes.url_helpers
 
 RSpec.describe Project, type: :model do
+  include Rails.application.routes.url_helpers
+
   let(:instructor) { create(:instructor) }
   let(:student)    { create(:student, nickname: "ClassicRichard") }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include Rails.application.routes.url_helpers
 
 RSpec.describe User, type: :model do
   describe 'relationships' do


### PR DESCRIPTION
- admins can see all projects, and note which other user made the project
- admins can delete any student clone for any project
- project clones are sorted by student nickname ascending and clone date descending
- project clones have relative dates/times showing instead of a fixed date
- fixed a bug with stale OAuth tokens, every login will refresh a user's GitHub token