### PR TITLE
Duplicate clones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,12 +23,12 @@ gem 'uglifier', '>= 1.3.0'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :test do
   gem 'capybara'
-  gem 'factory_bot_rails'
-  gem 'faker'
   gem 'launchy'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ end
 group :test do
   gem 'capybara'
   gem 'factory_bot_rails'
+  gem 'faker'
   gem 'launchy'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faker (2.14.0)
+      i18n (>= 1.6, < 2)
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
@@ -252,6 +254,7 @@ DEPENDENCIES
   byebug
   capybara
   factory_bot_rails
+  faker
   faraday
   figaro
   launchy

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -18,7 +18,9 @@ class ClonesController < ApplicationController
         ProjectBoardClonerWorker.perform_later(@project, @clone, params[:email])
         redirect_to root_path, alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
       else
-        flash[:alert] = "We're sorry, it looks like you already have a clone created"
+        existing_clone = Clone.find_by(user: current_user, project: @project)
+        click_here_link = helpers.link_to 'Click here', clone_path(existing_clone)
+        flash[:alert] = "We're sorry, it looks like you already have a clone created. #{click_here_link} to view your clone."
         render :new
       end
     else

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -28,6 +28,9 @@ class ClonesController < ApplicationController
     end
   end
 
+  def show
+    @clone = Clone.find(params[:id])
+  end
   # def update
   #   project = current_user.projects.find_by(hash_id: params[:project_id])
   #   clone = project.clones.find(params[:id])

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -30,6 +30,7 @@ class ClonesController < ApplicationController
 
   def show
     @clone = Clone.find(params[:id])
+    four_oh_four unless clone_belongs_to_current_user?(@clone)
   end
   # def update
   #   project = current_user.projects.find_by(hash_id: params[:project_id])
@@ -38,8 +39,13 @@ class ClonesController < ApplicationController
   #
   #   redirect_to admin_project_path(project), alert: "Cloning complete for #{clone.students}. Wait a minute and refresh the page."
   # end
+  private
 
   def clone_params
     params.require(:clone).permit(:url, :students)
+  end
+
+  def clone_belongs_to_current_user?(clone)
+    clone.user == current_user
   end
 end

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -20,7 +20,7 @@ class ClonesController < ApplicationController
       if @clone.save
         @clone.update(message: 'sending to sidekiq')
         ProjectBoardClonerWorker.perform_later(@project, @clone, params[:email])
-        redirect_to root_path, alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
+        redirect_to clone_path(@clone), alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
       else
         redirect_to root_path, alert: "We're sorry but we were unable to clone the project board."
       end

--- a/app/controllers/clones_controller.rb
+++ b/app/controllers/clones_controller.rb
@@ -10,15 +10,16 @@ class ClonesController < ApplicationController
   end
 
   def create
-    project = Project.find_by(hash_id: params[:project_hash_id])
-    if project
-      clone = project.clones.new(students: params[:students], user: current_user, url: '')
-      if clone.save
-        clone.update(message: 'sending to sidekiq')
-        ProjectBoardClonerWorker.perform_later(project, clone, params[:email])
+    @project = Project.find_by(hash_id: params[:project_hash_id])
+    if @project
+      @clone = @project.clones.new(students: params[:students], user: current_user, url: '')
+      if @clone.save
+        @clone.update(message: 'sending to sidekiq')
+        ProjectBoardClonerWorker.perform_later(@project, @clone, params[:email])
         redirect_to root_path, alert: "Thanks for your submission! We will send an email to #{params[:email]} when we finish getting everything setup. Follow the instructions in that message. Thanks!"
       else
-        redirect_to root_path, alert: "We're sorry but we were unable to clone the project board. If you continue to experience difficulty reach out to your instructor or point of contact."
+        flash[:alert] = "We're sorry, it looks like you already have a clone created"
+        render :new
       end
     else
       redirect_to root_path, alert: "We're sorry but we were unable to clone the project board."

--- a/app/models/clone.rb
+++ b/app/models/clone.rb
@@ -3,6 +3,8 @@ class Clone < ApplicationRecord
   belongs_to :user
 
   validates :students,  presence: true
+  validates :user_id, uniqueness: { scope: :project_id }
+  
   # validates :url,       presence: true
 
   # before_validation :set_owner_and_repo

--- a/app/models/clone.rb
+++ b/app/models/clone.rb
@@ -3,8 +3,8 @@ class Clone < ApplicationRecord
   belongs_to :user
 
   validates :students,  presence: true
-  validates :user_id, uniqueness: { scope: :project_id }
-  
+  validates :user, uniqueness: { scope: :project }
+
   # validates :url,       presence: true
 
   # before_validation :set_owner_and_repo

--- a/app/models/clone.rb
+++ b/app/models/clone.rb
@@ -9,6 +9,10 @@ class Clone < ApplicationRecord
 
   # before_validation :set_owner_and_repo
 
+  def valid_url?
+    url.present? && url.length > 0
+  end
+
   private
 
   # def set_owner_and_repo

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,6 @@ class Project < ApplicationRecord
 
   def get_clones
     clones.joins(:user)
-        .where(project: self)
         .order('users.nickname asc, users.email asc, clones.created_at desc')
   end
 end

--- a/app/views/clones/new.html.erb
+++ b/app/views/clones/new.html.erb
@@ -6,12 +6,12 @@
       <%= hidden_field_tag :project_hash_id, @project.hash_id  %>
       <p class="mt2">
         <strong>Who will be working on this project?</strong>
-        <%= text_field_tag :students, "" , class: "block col-12 field"  %>
+        <%= text_field_tag :students, @clone.students, class: "block col-12 field"  %>
         <em>e.g. <strong>Leslie Knope</strong> if solo; <strong>Leslie Knope and Duke Silver.</strong> if a team project.</em>
       </p>
       <p class="mt2">
         <strong>We'll send you an email when everything is finished. Where would you like us to send to?</strong>
-        <%= text_field_tag :email, "" , class: "block col-12 field"  %>
+        <%= text_field_tag :email, nil, class: "block col-12 field"  %>
       </p>
       <%= f.submit "Submit", class: "mt2 btn btn-primary mb1"  %>
     <% end %>

--- a/app/views/clones/new.html.erb
+++ b/app/views/clones/new.html.erb
@@ -11,7 +11,7 @@
       </p>
       <p class="mt2">
         <strong>We'll send you an email when everything is finished. Where would you like us to send to?</strong>
-        <%= text_field_tag :email, nil, class: "block col-12 field"  %>
+        <%= text_field_tag :email, current_user.email, class: "block col-12 field"  %>
       </p>
       <%= f.submit "Submit", class: "mt2 btn btn-primary mb1"  %>
     <% end %>

--- a/app/views/clones/show.html.erb
+++ b/app/views/clones/show.html.erb
@@ -1,4 +1,4 @@
 <h2>Clone of Project <%= @clone.project.name %></h2>
-<%= link_to 'View your repo on GitHub', @clone.url if @clone.url %>
+<%= link_to 'View your repo on GitHub', @clone.url if @clone.valid_url? %>
 <p>Students working on this project: <%= @clone.students %></p>
 <p>Status: <%= @clone.message %></p>

--- a/app/views/clones/show.html.erb
+++ b/app/views/clones/show.html.erb
@@ -1,0 +1,4 @@
+<h2>Clone of Project <%= @clone.project.name %></h2>
+<%= link_to 'View your repo on GitHub', @clone.url %>
+<p>Students working on this project: <%= @clone.students %></p>
+<p>Status: <%= @clone.message %></p>

--- a/app/views/clones/show.html.erb
+++ b/app/views/clones/show.html.erb
@@ -1,4 +1,4 @@
 <h2>Clone of Project <%= @clone.project.name %></h2>
-<%= link_to 'View your repo on GitHub', @clone.url %>
+<%= link_to 'View your repo on GitHub', @clone.url if @clone.url %>
 <p>Students working on this project: <%= @clone.students %></p>
 <p>Status: <%= @clone.message %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     resources :clones, only: [:new, :create, :update]
   end
 
+  resources :clones, only: :show
+
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+include FactoryBot::Syntax::Methods
+
+Clone.destroy_all
+User.destroy_all
+Project.destroy_all
+
+create_list(:project, 3)
+create_list(:clone, 3)
+create_list(:staff, 3)

--- a/spec/factories/clones.rb
+++ b/spec/factories/clones.rb
@@ -2,11 +2,9 @@ FactoryBot.define do
   factory :clone do
     students  {"Richard H." }
     project
-    user { student }
+    user { create(:student) }
     url { nil }
     github_project_id { nil }
     message { "" }
   end
 end
-
-

--- a/spec/factories/clones.rb
+++ b/spec/factories/clones.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :clone do
-    students  {"Richard H." }
+    students  {"#{Faker::Name.name}, #{Faker::Name.name}, #{Faker::Name.name}" }
     project
     user { create(:student) }
-    url { nil }
+    url { Faker::Internet.url }
     github_project_id { nil }
-    message { "" }
+    message { Faker::ChuckNorris.fact }
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :project do
     name { "Conveyor Belt" }
-    user { staff }
+    user { create(:staff) }
     hash_id { "abc123" }
     project_board_base_url { "https://github.com/turingschool-examples/watch-and-learn/projects/1" }
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :project do
-    name { "Conveyor Belt" }
+    name { Faker::Company.catch_phrase }
     user { create(:staff) }
-    hash_id { "abc123" }
-    project_board_base_url { "https://github.com/turingschool-examples/watch-and-learn/projects/1" }
+    hash_id { Faker::Crypto.md5 }
+    project_board_base_url { Faker::Internet.url }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,29 +1,28 @@
 FactoryBot.define do
   factory :user do
-    name { 'Plain User' }
+    name { Faker::Name.name }
     uid { 'NoID' }
     token { 'NotaRealToken' }
     nickname { 'NoNickname123456789' }
-    email { 'admin@example.com' }
+    email { Faker::Internet.email }
     admin { false }
   end
 
   factory :student, parent: :user do
-    name { 'Richard B. Hathaway' }
+    name { Faker::Name.name }
     uid { '11797474' }
     token { ENV['GITHUB_TESTING_STUDENT_TOKEN'] }
     nickname { 'ClassicRichard' }
-    email { 'student@example.com' }
+    email { Faker::Internet.email }
     admin { false }
   end
 
   factory :instructor, aliases: [:staff], parent: :user do
-    name { 'Ian Douglas' }
+    name { Faker::Name.name }
     uid { '168030' }
     token { ENV['GITHUB_TESTING_USER_TOKEN'] }
     nickname { 'iandouglas' }
-    email { 'iandouglas@turing.io' }
+    email { Faker::Internet.email }
     admin { true }
   end
 end
-

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -45,26 +45,40 @@ feature 'User creates a new clone' do
     expect(page).to have_content('we were unable to clone the project board')
   end
 
-  scenario 'when that clone exists, it does not create duplicates' do
-    project = create(:project)
-    student = create(:student)
-    clone = create(:clone, user: student, project: project)
-    students = 'Dasher, Prancer, Vixen'
-    email = 'studentemail@gmail.com'
+  describe 'when that clone already exists' do
+    before :each do
+      @clone = create(:clone)
+      mock_login(@clone.user)
 
-    mock_login(student)
-
-    visit new_project_clone_path(project)
-
-    fill_in :students, with: students
-    fill_in :email, with: email
-
-    click_button 'Submit'
-
-    within '#new_clone' do
-      expect(find('#students').value).to eq(students)
+      @students = 'Dasher, Prancer, Vixen'
+      @email = 'studentemail@gmail.com'
     end
 
-    expect(page).to have_content("We're sorry, it looks like you already have a clone created")
+    it 'does not create duplicates' do
+      visit new_project_clone_path(@clone.project)
+
+      fill_in :students, with: @students
+      fill_in :email, with: @email
+
+      click_button 'Submit'
+
+      within '#new_clone' do
+        expect(find('#students').value).to eq(@students)
+      end
+
+      expect(page).to have_content("We're sorry, it looks like you already have a clone created.")
+    end
+
+    it 'links to the show page for the existing clone' do
+      visit new_project_clone_path(@clone.project)
+
+      fill_in :students, with: @students
+      fill_in :email, with: @email
+
+      click_button 'Submit'
+
+      expect(page).to have_content('Click here to view your clone.')
+      expect(page).to have_link('Click here', href: clone_path(@clone))
+    end
   end
 end

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -19,15 +19,26 @@ feature 'User creates a new clone' do
       expect {
         click_on 'Submit'
       }.to change { Clone.count }.by(1)
-
-      expect(current_path).to eq(root_path)
-      expect(page).to have_content('Thanks for your submission!')
     end
 
     scenario 'their email is prepopulated in the form' do
       visit new_project_clone_path(project_id: @project.hash_id)
 
       expect(find('#email').value).to eq(@student.email)
+    end
+
+    scenario 'it redirects to the clone show page' do
+      visit new_project_clone_path(project_id: @project.hash_id)
+
+      fill_in :students, with: 'Flower, Thumper, Bambi'
+      fill_in :email, with: 'bambi@example.com'
+
+      click_on 'Submit'
+
+      clone = Clone.last
+
+      expect(current_path).to eq(clone_path(clone))
+      expect(page).to have_content('Thanks for your submission!')
     end
 
     scenario 'student cannot create a clone when that project has been deleted by an admin' do

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -5,14 +5,8 @@ feature 'User creates a new clone' do
     instructor = create(:instructor, nickname: 'iandouglas')
     student = create(:student)
     project = create(:project, hash_id: 'abc123', user: instructor, project_board_base_url: 'https://github.com/turingschool/newb-tube/projects/1')
-    clone = create(:clone,
-                   students: 'Richard H.',
-                   project: project,
-                   user: student,
-                   url: 'http://abc/123'
-    )
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(student)
-    allow(ApprovedOrganizations).to receive(:all).and_return(%w(not-a-real-organization))
+
+    mock_login(student)
 
     expect(ProjectBoardClonerWorker).to receive(:perform_later)#.with array_including(project, clone, "bambi@example.com")
 
@@ -29,7 +23,7 @@ feature 'User creates a new clone' do
     expect(page).to have_content('Thanks for your submission!')
   end
 
-  scenario 'student cannot create a clone because ... reasons' do
+  scenario 'student cannot create a clone when that project has been deleted by an admin' do
     instructor = create(:instructor, nickname: 'iandouglas')
     student = create(:student)
     project = create(:project, hash_id: 'abc123', user: instructor, project_board_base_url: 'https://github.com/turingschool/newb-tube/projects/1')
@@ -49,5 +43,28 @@ feature 'User creates a new clone' do
 
     expect(current_path).to eq(root_path)
     expect(page).to have_content('we were unable to clone the project board')
+  end
+
+  scenario 'when that clone exists, it does not create duplicates' do
+    project = create(:project)
+    student = create(:student)
+    clone = create(:clone, user: student, project: project)
+    students = 'Dasher, Prancer, Vixen'
+    email = 'studentemail@gmail.com'
+
+    mock_login(student)
+
+    visit new_project_clone_path(project)
+
+    fill_in :students, with: students
+    fill_in :email, with: email
+
+    click_button 'Submit'
+
+    within '#new_clone' do
+      expect(find('#students').value).to eq(students)
+    end
+
+    expect(page).to have_content("We're sorry, it looks like you already have a clone created")
   end
 end

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -24,7 +24,11 @@ feature 'User creates a new clone' do
       expect(page).to have_content('Thanks for your submission!')
     end
 
+    scenario 'their email is prepopulated in the form' do
+      visit new_project_clone_path(project_id: @project.hash_id)
 
+      expect(find('#email').value).to eq(@student.email)
+    end
 
     scenario 'student cannot create a clone when that project has been deleted by an admin' do
       visit new_project_clone_path(project_id: @project.hash_id)
@@ -41,7 +45,7 @@ feature 'User creates a new clone' do
       expect(page).to have_content('we were unable to clone the project board')
     end
   end
-
+  
   describe 'when that clone already exists' do
     before :each do
       @clone = create(:clone)

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -1,48 +1,45 @@
 require 'rails_helper'
 
 feature 'User creates a new clone' do
-  scenario 'with valid options' do
-    instructor = create(:instructor, nickname: 'iandouglas')
-    student = create(:student)
-    project = create(:project, hash_id: 'abc123', user: instructor, project_board_base_url: 'https://github.com/turingschool/newb-tube/projects/1')
+  describe 'with valid options' do
+    before :each do
+      @student = create(:student)
+      @project = create(:project)
+      mock_login(@student)
+    end
 
-    mock_login(student)
+    scenario 'it creates successfully' do
+      expect(ProjectBoardClonerWorker).to receive(:perform_later)#.with array_including(project, clone, "bambi@example.com")
 
-    expect(ProjectBoardClonerWorker).to receive(:perform_later)#.with array_including(project, clone, "bambi@example.com")
+      visit new_project_clone_path(project_id: @project.hash_id)
 
-    visit new_project_clone_path(project_id: project.hash_id)
+      fill_in :students, with: 'Flower, Thumper, Bambi'
+      fill_in :email, with: 'bambi@example.com'
 
-    fill_in :students, with: 'Flower, Thumper, Bambi'
-    fill_in :email, with: 'bambi@example.com'
+      expect {
+        click_on 'Submit'
+      }.to change { Clone.count }.by(1)
 
-    expect {
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content('Thanks for your submission!')
+    end
+
+
+
+    scenario 'student cannot create a clone when that project has been deleted by an admin' do
+      visit new_project_clone_path(project_id: @project.hash_id)
+
+      fill_in :students, with: 'Flower, Thumper, Bambi'
+      fill_in :email, with: 'bambi@example.com'
+
+      # let's imagine here that an admin deletes a project, the clone will no longer save properly
+      @project.destroy
+
       click_on 'Submit'
-    }.to change { Clone.count }.by(1)
 
-    expect(current_path).to eq(root_path)
-    expect(page).to have_content('Thanks for your submission!')
-  end
-
-  scenario 'student cannot create a clone when that project has been deleted by an admin' do
-    instructor = create(:instructor, nickname: 'iandouglas')
-    student = create(:student)
-    project = create(:project, hash_id: 'abc123', user: instructor, project_board_base_url: 'https://github.com/turingschool/newb-tube/projects/1')
-
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(student)
-    allow(ApprovedOrganizations).to receive(:all).and_return(%w(not-a-real-organization))
-
-    visit new_project_clone_path(project_id: project.hash_id)
-
-    fill_in :students, with: 'Flower, Thumper, Bambi'
-    fill_in :email, with: 'bambi@example.com'
-
-    # let's imagine here that an admin deletes a project, the clone will no longer save properly
-    project.destroy
-
-    click_on 'Submit'
-
-    expect(current_path).to eq(root_path)
-    expect(page).to have_content('we were unable to clone the project board')
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content('we were unable to clone the project board')
+    end
   end
 
   describe 'when that clone already exists' do

--- a/spec/features/student/student_can_create_a_clone_spec.rb
+++ b/spec/features/student/student_can_create_a_clone_spec.rb
@@ -45,7 +45,7 @@ feature 'User creates a new clone' do
       expect(page).to have_content('we were unable to clone the project board')
     end
   end
-  
+
   describe 'when that clone already exists' do
     before :each do
       @clone = create(:clone)
@@ -55,31 +55,22 @@ feature 'User creates a new clone' do
       @email = 'studentemail@gmail.com'
     end
 
-    it 'does not create duplicates' do
+    scenario 'it redirects to that clone show page' do
       visit new_project_clone_path(@clone.project)
 
-      fill_in :students, with: @students
-      fill_in :email, with: @email
-
-      click_button 'Submit'
-
-      within '#new_clone' do
-        expect(find('#students').value).to eq(@students)
-      end
-
-      expect(page).to have_content("We're sorry, it looks like you already have a clone created.")
+      expect(current_path).to eq(clone_path(@clone))
     end
 
-    it 'links to the show page for the existing clone' do
-      visit new_project_clone_path(@clone.project)
-
-      fill_in :students, with: @students
-      fill_in :email, with: @email
-
-      click_button 'Submit'
-
-      expect(page).to have_content('Click here to view your clone.')
-      expect(page).to have_link('Click here', href: clone_path(@clone))
-    end
+    # scenario 'links to the show page for the existing clone' do
+    #   visit new_project_clone_path(@clone.project)
+    #
+    #   fill_in :students, with: @students
+    #   fill_in :email, with: @email
+    #
+    #   click_button 'Submit'
+    #
+    #   expect(page).to have_content('Click here to view your clone.')
+    #   expect(page).to have_link('Click here', href: clone_path(@clone))
+    # end
   end
 end

--- a/spec/features/student/student_can_view_clone_spec.rb
+++ b/spec/features/student/student_can_view_clone_spec.rb
@@ -25,13 +25,13 @@ feature 'User visits clone show page' do
   end
 
   it 'does not show repo link if repo has not been successfully created' do
-    clone = create(:clone, url: nil)
+    clone = create(:clone, url: "")
     student = clone.user
 
     mock_login(student)
 
     visit clone_path(clone)
 
-    expect(page).to_not have_content("View your repo on GitHub")
+    expect(page).to_not have_link("View your repo on GitHub")
   end
 end

--- a/spec/features/student/student_can_view_clone_spec.rb
+++ b/spec/features/student/student_can_view_clone_spec.rb
@@ -14,4 +14,13 @@ feature 'User visits clone show page' do
     expect(page).to have_content("Status: #{clone.message}")
     expect(page).to have_content("Clone of Project #{clone.project.name}")
   end
+
+  it 'does not allow you to view another students clone' do
+    clone = create(:clone)
+    different_student = create(:student)
+
+    mock_login(different_student)
+
+    expect { visit clone_path(clone) }.to raise_error(ActionController::RoutingError)
+  end
 end

--- a/spec/features/student/student_can_view_clone_spec.rb
+++ b/spec/features/student/student_can_view_clone_spec.rb
@@ -23,4 +23,15 @@ feature 'User visits clone show page' do
 
     expect { visit clone_path(clone) }.to raise_error(ActionController::RoutingError)
   end
+
+  it 'does not show repo link if repo has not been successfully created' do
+    clone = create(:clone, url: nil)
+    student = clone.user
+
+    mock_login(student)
+
+    visit clone_path(clone)
+
+    expect(page).to_not have_content("View your repo on GitHub")
+  end
 end

--- a/spec/features/student/student_can_view_clone_spec.rb
+++ b/spec/features/student/student_can_view_clone_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'User visits clone show page' do
+  it 'displays the clone repo link and message' do
+    clone = create(:clone)
+    student = clone.user
+
+    mock_login(student)
+
+    visit clone_path(clone)
+
+    expect(page).to have_link('View your repo on GitHub', href: clone.url)
+    expect(page).to have_content("Students working on this project: #{clone.students}")
+    expect(page).to have_content("Status: #{clone.message}")
+    expect(page).to have_content("Clone of Project #{clone.project.name}")
+  end
+end

--- a/spec/models/clone_spec.rb
+++ b/spec/models/clone_spec.rb
@@ -11,5 +11,26 @@ RSpec.describe Clone, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of :students }
+
+    describe 'project and student uniqueness' do
+      it 'validates the uniqueness of the student AND the project simultaneously' do
+        project = create(:project)
+        student = create(:student)
+        clone = Clone.create(project: project, user: student, students: '1, 2, 3')
+        expect(clone).to be_valid
+        duplicate_clone = Clone.create(project: project, user: student, students: '4, 5, 6')
+        expect(duplicate_clone).to be_invalid
+      end
+
+      it 'is still valid if the student or the project are different' do
+        project = create(:project)
+        student = create(:student)
+        clone = Clone.create(project: project, user: student, students: '1, 2, 3')
+        different_user_clone = Clone.create(project: project, user: create(:student), students: '1, 2, 3')
+        different_project_clone = Clone.create(project: create(:project), user: student, students: '1, 2, 3')
+        expect(different_user_clone).to be_valid
+        expect(different_project_clone).to be_valid
+      end
+    end
   end
 end

--- a/spec/models/clone_spec.rb
+++ b/spec/models/clone_spec.rb
@@ -33,4 +33,23 @@ RSpec.describe Clone, type: :model do
       end
     end
   end
+
+  describe 'instance methods' do
+    describe '#valid_url?' do
+      it 'treats a github repo url as valid' do
+        clone = create(:clone, url: 'https://github.com/agallant121/adopt_dont_shop_2005')
+        expect(clone.valid_url?).to be(true)
+      end
+
+      it 'does not treat nil as valid' do
+        clone = create(:clone, url: nil)
+        expect(clone.valid_url?).to be(false)
+      end
+
+      it 'does not treat an empty string as valid' do
+        clone = create(:clone, url: "")
+        expect(clone.valid_url?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Project, type: :model do
     it { should have_many(:clones) }
   end
 
-  describe 'methods' do
+  describe 'instance methods' do
     scenario '.to_param' do
       project = create(:project, user: instructor)
       expect(admin_project_path(project)).to eq("/admin/projects/#{project.hash_id}")
@@ -33,22 +33,38 @@ RSpec.describe Project, type: :model do
       expect(project.repo_path).to eq('ian/douglas')
     end
 
-    scenario '.get_clones' do
-      project = create(:project, user: instructor, project_board_base_url: 'http://github.com/ian/douglas')
-      student_2 = create(:student, nickname: 'AwesomeCoder')
-      student_3 = create(:student, nickname: 'ZeroCool')
-      s1_clone_1 = create(:clone, project: project, user: student, created_at: 10.seconds.ago)   # 3rd
-      s1_clone_2 = create(:clone, project: project, user: student, created_at: 5.seconds.ago)    # 2nd
-      s2_clone_1 = create(:clone, project: project, user: student_2, created_at: 10.seconds.ago) # 1st
-      s3_clone_1 = create(:clone, project: project, user: student_3, created_at: 5.seconds.ago)  # 4th
-      s3_clone_2 = create(:clone, project: project, user: student_3, created_at: 10.seconds.ago) # 5th
+    describe '.get_clones' do
+      it 'orders by user nickname, user email, and clone created at timestamp' do
+        project = create(:project, user: instructor, project_board_base_url: 'http://github.com/ian/douglas')
 
-      clone_list = project.get_clones
-      expect(clone_list[0].id).to eq(s2_clone_1.id)
-      expect(clone_list[1].id).to eq(s1_clone_2.id)
-      expect(clone_list[2].id).to eq(s1_clone_1.id)
-      expect(clone_list[3].id).to eq(s3_clone_1.id)
-      expect(clone_list[4].id).to eq(s3_clone_2.id)
+        student_1 = create(:student, nickname: 'ZeroChill', email: 'ZeroChill@gmail.com')
+        student_2 = create(:student, nickname: 'BigSpender', email: 'BigSpender@gmail.com')
+        student_3 = create(:student, nickname: 'AllStar', email: 'AllStar@gmail.com')
+        student_4 = create(:student, nickname: 'Yessirybob', email: 'Yessirybob@gmail.com')
+        student_5 = create(:student, nickname: 'Yessirybob', email: 'Yessirybob@gmail.com')
+        student_6 = create(:student, nickname: 'Yessirybob', email: 'Nosirybob@gmail.com')
+
+        clone_1 = create(:clone, project: project, user: student_1, created_at: 10.seconds.ago)   # 3rd
+        clone_2 = create(:clone, project: project, user: student_2, created_at: 5.seconds.ago)    # 2nd
+        clone_3 = create(:clone, project: project, user: student_3, created_at: 10.seconds.ago) # 1st
+        clone_4 = create(:clone, project: project, user: student_4, created_at: 5.seconds.ago)  # 4th
+        clone_5 = create(:clone, project: project, user: student_5, created_at: 10.seconds.ago) # 5th
+        clone_6 = create(:clone, project: project, user: student_6, created_at: 10.seconds.ago) # 5th
+
+        clone_list = project.get_clones
+        expect(clone_list[0].id).to eq(clone_3.id)
+        expect(clone_list[1].id).to eq(clone_2.id)
+        expect(clone_list[2].id).to eq(clone_6.id)
+        expect(clone_list[3].id).to eq(clone_4.id)
+        expect(clone_list[4].id).to eq(clone_5.id)
+        expect(clone_list[5].id).to eq(clone_1.id)
+      end
+
+      it 'does not return clones from different projects' do
+        project = create(:project, user: instructor, project_board_base_url: 'http://github.com/ian/douglas')
+        different_clone = create(:clone)
+        expect(project.get_clones).to_not include(different_clone)
+      end
     end
   end
 end


### PR DESCRIPTION
* Prevents a student from filling out the clone form twice and creating duplicate clones
* Adds validations to Clone model to check for this condition
* Updates sad path so the student is notified when they create this condition
* Adds a clone show page where a student can see their clone and its status
* Links to the existing clone show page when a student tries to create a duplicate

Still to do:

* Check for this condition in the background worker (not sure if there's a scenario where this would be an issue)
* Only show link to repo on clone show page if the repo was created
* Probably makes for a better user experience if we alert the user that they already have this clone before they fill in the form. Does it make sense for the new clone link to redirect to the existing clone show page if the clone already exists?